### PR TITLE
Add blog comment section

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -11,6 +11,7 @@ import matter from "gray-matter";
 import Link from "next/link";
 import Head from "next/head";
 import type { Metadata, ResolvingMetadata } from "next";
+import BlogComments from "@/components/BlogComments";
 
 const getPostContent = (slug: string) => {
   const folder = "./content/blog_posts/";
@@ -167,6 +168,7 @@ export default function BlogPost(props: any) {
         <article className="prose prose-slate prose-invert m-auto pb-6 lg:prose-xl prose-a:no-underline prose-a:transition hover:prose-a:text-slate-400 prose-pre:bg-slate-200 prose-pre:text-slate-800 md:pb-12">
           <Markdown>{post.content}</Markdown>
         </article>
+        <BlogComments slug={slug} />
       </section>
     </>
   );

--- a/backend/comments.php
+++ b/backend/comments.php
@@ -1,0 +1,98 @@
+<?php
+
+session_save_path(__DIR__ . '/sessions');
+session_start();
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header("Access-Control-Allow-Credentials: true");
+
+$allowedOrigins = array(
+    'https://www.the-still-river.com',
+    'https://the-still-river.com',
+    'http://localhost:3000',
+    'https://mingra02.github.io'
+);
+
+if (isset($_SERVER['HTTP_ORIGIN'])) {
+    if (in_array($_SERVER['HTTP_ORIGIN'], $allowedOrigins)) {
+        header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    exit(0);
+}
+
+include 'dbconn.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['slug'])) {
+    $slug = $_GET['slug'];
+    $page = isset($_GET['page']) ? intval($_GET['page']) : 0;
+    $resultsPerPage = 10;
+    $offset = $page * $resultsPerPage;
+
+    $stmt = $conn->prepare(
+        "SELECT c.id, c.blog_slug, c.content, c.created_at, u.id AS user_id, u.username, u.avatar
+         FROM BlogComments c
+         JOIN Users u ON c.user_id = u.id
+         WHERE c.blog_slug = :slug
+         ORDER BY c.created_at DESC
+         LIMIT :limit OFFSET :offset"
+    );
+    $stmt->bindParam(':slug', $slug);
+    $stmt->bindParam(':limit', $resultsPerPage, PDO::PARAM_INT);
+    $stmt->bindParam(':offset', $offset, PDO::PARAM_INT);
+    $stmt->execute();
+    $comments = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($comments);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!isset($_SESSION['session_id'])) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Please log in to comment']);
+        exit;
+    }
+
+    $data = json_decode(file_get_contents('php://input'), true);
+    if (!isset($data['slug'], $data['content'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing slug or content']);
+        exit;
+    }
+
+    $sessionId = $_SESSION['session_id'];
+    $stmt = $conn->prepare("SELECT id FROM Users WHERE session_id = :session_id");
+    $stmt->bindParam(':session_id', $sessionId);
+    $stmt->execute();
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$user) {
+        http_response_code(401);
+        echo json_encode(['error' => 'User not found']);
+        exit;
+    }
+
+    $stmt = $conn->prepare(
+        "INSERT INTO BlogComments (blog_slug, user_id, content, created_at)
+         VALUES (:slug, :user_id, :content, NOW())"
+    );
+    $stmt->execute([
+        ':slug' => $data['slug'],
+        ':user_id' => $user['id'],
+        ':content' => $data['content']
+    ]);
+
+    $commentId = $conn->lastInsertId();
+    http_response_code(201);
+    echo json_encode(['message' => 'Comment created', 'comment_id' => $commentId]);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['error' => 'Method not allowed']);
+
+?>

--- a/components/AddComment.tsx
+++ b/components/AddComment.tsx
@@ -1,0 +1,86 @@
+import React, { Suspense, useEffect, useRef, useState } from "react";
+import "@mdxeditor/editor/style.css";
+// @ts-ignore
+import { MDXEditorMethods } from "@mdxeditor/editor";
+import Editor from "@/components/Editor";
+
+interface AddCommentProps {
+  slug: string;
+  onCommentSubmit: () => void;
+}
+
+interface User {
+  username: string;
+  id: number;
+}
+
+const AddComment: React.FC<AddCommentProps> = ({ slug, onCommentSubmit }) => {
+  const mdxEditorRef = useRef<MDXEditorMethods>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    fetch("https://www.the-still-river.com/api/forum/user.php", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data.error) {
+          setUser(data);
+        }
+      });
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    let content = mdxEditorRef.current?.getMarkdown() || "";
+
+    const response = await fetch(
+      "https://www.the-still-river.com/api/forum/comments.php",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ slug, content }),
+        credentials: "include",
+      },
+    );
+
+    if (response.ok) {
+      mdxEditorRef.current?.setMarkdown("");
+      onCommentSubmit();
+    }
+  };
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8 rounded-xl bg-slate-950/70 p-6 pb-2 shadow-lg">
+      <form className="flex flex-col space-y-4" onSubmit={handleSubmit}>
+        <label htmlFor="comment" className="text-xl font-bold text-slate-200">
+          Add Comment
+        </label>
+        <Suspense>
+          <Editor markdown={""} editorRef={mdxEditorRef} />
+        </Suspense>
+        <div className="flex w-full justify-end">
+          <button
+            type="submit"
+            className="flex w-full justify-center rounded bg-teal-600 px-3 py-2 font-bold text-teal-100 transition-colors hover:bg-teal-700 hover:text-teal-200 sm:w-auto sm:px-5"
+          >
+            <p>Post Comment</p>
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default AddComment;

--- a/components/BlogComments.tsx
+++ b/components/BlogComments.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import Image from "next/image";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import AddComment from "@/components/AddComment";
+import Link from "next/link";
+
+interface CommentData {
+  id: number;
+  blog_slug: string;
+  user_id: number;
+  username: string;
+  avatar: string;
+  content: string;
+  created_at: string;
+}
+
+interface BlogCommentsProps {
+  slug: string;
+}
+
+const BlogComments: React.FC<BlogCommentsProps> = ({ slug }) => {
+  const [comments, setComments] = useState<CommentData[]>([]);
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchComments = useCallback(async () => {
+    setIsLoading(true);
+    const res = await fetch(
+      `https://www.the-still-river.com/api/forum/comments.php?slug=${slug}&page=${page}`,
+    );
+    const data = await res.json();
+    setComments(data);
+    setIsLoading(false);
+  }, [slug, page]);
+
+  useEffect(() => {
+    fetchComments();
+  }, [fetchComments]);
+
+  return (
+    <div className="m-auto mb-12 mt-8 w-[95%] max-w-3xl">
+      <h2 className="mb-4 text-2xl font-bold text-slate-200">Comments</h2>
+      {comments.map((comment) => (
+        <div
+          key={comment.id}
+          className="grid grid-cols-[auto_1fr] gap-4 border-t border-white/25 py-4"
+        >
+          <Image
+            src={`https://www.the-still-river.com/img/forum/avatars/${comment.avatar == "0" ? "0" : comment.user_id}.jpg`}
+            alt={comment.username}
+            width={64}
+            height={64}
+            className="h-10 w-10 rounded-full md:h-16 md:w-16"
+          />
+          <div>
+            <div className="flex flex-wrap items-baseline justify-between gap-4">
+              <Link href={`/forum/users/?user_id=${comment.user_id}`}
+                className="font-bold text-slate-200 transition-colors hover:text-indigo-400">
+                {comment.username}
+              </Link>
+              <p className="text-sm text-slate-400">
+                {new Date(comment.created_at).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+              </p>
+            </div>
+            <div className="prose prose-invert mt-2 !max-w-none">
+              <Markdown remarkPlugins={[remarkGfm]}>{comment.content}</Markdown>
+            </div>
+          </div>
+        </div>
+      ))}
+      <div className="mt-4 flex justify-between">
+        <button
+          onClick={() => setPage((p) => Math.max(p - 1, 0))}
+          disabled={page === 0}
+          className="rounded bg-slate-800 px-3 py-1 text-slate-200 disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <button
+          onClick={() => setPage((p) => p + 1)}
+          disabled={comments.length < 10}
+          className="rounded bg-slate-800 px-3 py-1 text-slate-200 disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+      <AddComment slug={slug} onCommentSubmit={fetchComments} />
+    </div>
+  );
+};
+
+export default BlogComments;


### PR DESCRIPTION
## Summary
- allow posting and reading blog comments
- show comments on blog posts with pagination

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c3215744832e920164656c80138d